### PR TITLE
Add yml file for pypi workflow

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -43,6 +43,6 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution to PyPI
-        uses: pypa/gh-actions-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
 # could add signing into github release here

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build a binary wheel and source tarball
       run: python3 -m build
     - name: Store distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -38,7 +38,7 @@ jobs:
       id-token: write # for trusted publishing
     steps:
       - name: Download all dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,48 @@
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: publish to pypi
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.X"
+
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and source tarball
+      run: python3 -m build
+    - name: Store distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish disribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/universalSOAP
+    permissions:
+      id-token: write # for trusted publishing
+    steps:
+      - name: Download all dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-actions-pypi-publish@release/v1
+
+# could add signing into github release here

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import setuptools
 setuptools.setup(
     name="universalSOAP",
     version="0.1.0b",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     packages=setuptools.find_packages(exclude=["tests"]),
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
Hi, this pull-request adds the yml file for the PyPI distribution continuously integrated via Trusted Publisher Management. To invoke the creation of the distribution a tag needs to be added to this or any other following commit.